### PR TITLE
fix: Use performance.now() in profile spec-helper

### DIFF
--- a/lib/spec-helper/profile.js
+++ b/lib/spec-helper/profile.js
@@ -8,9 +8,9 @@
 //
 // Returns the value returned by the given function.
 window.measure = function (description, fn) {
-	const start = Date.now();
+	const start = window.performance.now();
 	const value = fn();
-	const result = Date.now() - start;
+	const result = window.performance.now() - start;
 	console.log(description, result);
 	return value;
 };


### PR DESCRIPTION
https://stackoverflow.com/questions/30795525/performance-now-vs-date-now

`window.performance.now()` is more accurate.