### PR TITLE
fix: always check installation

### DIFF
--- a/lib/spec-helper/install-dep.js
+++ b/lib/spec-helper/install-dep.js
@@ -45,4 +45,13 @@ export default async function (pkg, version = null) {
 	if (shouldInstall) {
 		await install(pkg, version);
 	}
+
+	// check if pkg is installed
+	try {
+		require.resolve(`${pkg}`);
+	} catch (e) {
+		// try installation without version
+		await install(pkg);
+	}
+
 };


### PR DESCRIPTION
This always checks the installation of the helpers before requiring them, and if not found it tries to install them again. The installation sometimes fails, and it needs to be tried again!

Trying to fix #125 