### PR TITLE
Allow typescript tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /npm-debug.log
 /debug.log
+/dist

--- a/README.md
+++ b/README.md
@@ -40,6 +40,34 @@ If you want to use all the default options, simply pass the module name as the `
 Note that your `package.json` may be cached by Atom's compile cache when running tests with Atom's GUI test runner, so
 if adding or changing that field doesn't seem to work, try quitting and restarting Atom.
 
+## Writing TypeScript Tests
+
+⚠ NOTE: If you use a [custom runner](#Programmatic-Usage) that file (`custom-runner.js`) must be a `.js` file.
+
+You must use [`atom-ts-transpiler`](https://www.npmjs.com/package/atom-ts-transpiler) to transpile `.ts` files to `.js` on the fly in Atom.
+
+```bash
+npm i -D atom-ts-transpiler typescript
+```
+
+In your `package.json` file you must add a `""`
+
+```javascript
+{
+  "name": "my-package",
+  // ...
+  "atomTranspilers": [
+    {
+      "transpiler": "atom-ts-transpiler",
+      "glob": "{!(node_modules)/**/,}*.ts?(x)",
+      "options": {...}
+    }
+  ]
+}
+```
+
+For more options see the [`atom-ts-transpiler` documentation](https://github.com/smhxx/atom-ts-transpiler/wiki/Setup-&-Configuration)
+
 ### Programmatic Usage
 
 If you'd like to perform more customization of your testing environment, you can create a custom runner while still utilizing

--- a/lib/create-runner.js
+++ b/lib/create-runner.js
@@ -93,19 +93,19 @@ export default function createRunner(options = {}, configFunc) {
 			configFunc = function () {};
 		}
 	}
-	if (/\.(js|coffee)$/.test(options.suffix)) {
+	if (/\.(js|coffee|ts)$/.test(options.suffix)) {
 		options.fileGlob = `**/*${options.suffix}`;
 		options.fileRegexp = new RegExp(options.suffix);
 	} else {
-		options.fileGlob = `**/*${options.suffix}.+(js|coffee)`;
-		options.fileRegexp = new RegExp(`${options.suffix}\\.(js|coffee)`);
+		options.fileGlob = `**/*${options.suffix}.+(js|coffee|ts)`;
+		options.fileRegexp = new RegExp(`${options.suffix}\\.(js|coffee|ts)`);
 	}
-	if (/\.(js|coffee)$/.test(options.legacySuffix)) {
+	if (/\.(js|coffee|ts)$/.test(options.legacySuffix)) {
 		options.fileLegacyGlob = `**/*${options.legacySuffix}`;
 		options.fileLegacyRegexp = new RegExp(options.legacySuffix);
 	} else {
-		options.fileLegacyGlob = `**/*${options.legacySuffix}.+(js|coffee)`;
-		options.fileLegacyRegexp = new RegExp(`${options.legacySuffix}\\.(js|coffee)`);
+		options.fileLegacyGlob = `**/*${options.legacySuffix}.+(js|coffee|ts)`;
+		options.fileLegacyRegexp = new RegExp(`${options.legacySuffix}\\.(js|coffee|ts)`);
 	}
 
 	return async ({ testPaths, buildAtomEnvironment, buildDefaultApplicationDelegate, logFile, headless, legacyTestRunner }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -542,6 +542,12 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/jasmine": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.14.tgz",
+      "integrity": "sha512-Fkgk536sHPqcOtd+Ow+WiUNuk0TSo/BntKkF8wSvcd6M2FvPjeXcUE6Oz/bwDZiUZEaXLslAgw00Q94Pnx6T4w==",
+      "dev": true
+    },
     "@types/minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
@@ -734,6 +740,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
+    "atom-ts-transpiler": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/atom-ts-transpiler/-/atom-ts-transpiler-1.5.2.tgz",
+      "integrity": "sha512-X1Ii+whd+9MuwzV6nXyqpAOq886PH70YcCDDXgFGwkkfMChJndbedBAPUhnp9JqgoktiY0JLkOMmFsdBwuf70g==",
       "dev": true
     },
     "balanced-match": {
@@ -6928,6 +6940,12 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,16 @@
   "repository": "https://github.com/UziTech/atom-jasmine3-test-runner",
   "main": "index.js",
   "atomTestRunner": "./spec/runner",
+  "atomTranspilers": [
+    {
+      "transpiler": "atom-ts-transpiler",
+      "glob": "{!(node_modules)/**/,}*.ts?(x)"
+    }
+  ],
   "scripts": {
     "test": "atom --test ./spec",
     "lint": "eslint .",
-    "semantic-release": "semantic-release"
+    "tsc": "tsc"
   },
   "keywords": [
     "atom",
@@ -43,7 +49,10 @@
     "@semantic-release/github": "^7.1.1",
     "@semantic-release/npm": "^7.0.6",
     "@semantic-release/release-notes-generator": "^9.0.1",
+    "@types/jasmine": "^3.5.14",
+    "atom-ts-transpiler": "^1.5.2",
     "eslint": "^7.11.0",
-    "semantic-release": "^17.2.1"
+    "semantic-release": "^17.2.1",
+    "typescript": "^4.0.3"
   }
 }

--- a/spec/typescript/typescript-spec-v1.ts
+++ b/spec/typescript/typescript-spec-v1.ts
@@ -1,0 +1,8 @@
+describe("typescript", () => {
+	describe("passing", () => {
+		it("should pass", () => {
+			expect(true).toBe(true);
+			return;
+		});
+	});
+});

--- a/spec/typescript/typescript-spec.ts
+++ b/spec/typescript/typescript-spec.ts
@@ -1,0 +1,6 @@
+describe("typescript", () => {
+	it("should pass", () => {
+		//// @ts-ignore
+		pass();
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
Allows spec files to be written in typescript with [atom-ts-transpiler](https://www.npmjs.com/package/atom-ts-transpiler)

fixes #149